### PR TITLE
Removed deprecated config option, add updated title suffix

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,8 +32,8 @@ export default function (eleventyConfig) {
                     '</span>'
             },
             productName: 'Developer Healthcheck Workshops',
-            organisationName: 'Home Office'
         },
+        titleSuffix: 'Home Office',
         footer: {
             meta: {
                 items: [


### PR DESCRIPTION
## Purpose of pull request
Removed deprecated config option, add updated title suffix

## How to test
Spin up locally, check the title has Home Office as a suffix, rather than the default GOV.UK.